### PR TITLE
fix: restore typescript dev deps

### DIFF
--- a/backend-nest/package.json
+++ b/backend-nest/package.json
@@ -26,6 +26,6 @@
     "@types/express": "^4.17.13",
     "@types/node": "^18.11.0",
     "@types/sequelize": "^4.28.0",
-    "": "^4.9.0"
+    "typescript": "^4.9.0"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "": "^5.0.0",
+    "typescript": "^5.0.0",
     "vite": "^4.2.0",
     "@vitejs/plugin-react": "^3.1.0"
   }


### PR DESCRIPTION
## Summary
- fix corrupted dev dependency names in backend and frontend package manifests

## Testing
- `npm test` (backend, expected failure: Missing script "test")
- `npm run build` (backend, expected failure: `nest` not found)
- `npm test` (frontend, expected failure: Missing script "test")
- `npm run build` (frontend, expected failure: missing modules)


------
https://chatgpt.com/codex/tasks/task_e_68951f10df548330b37f860c627c336a