### PR TITLE
Register PdfService provider for SignalController

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -12,7 +12,7 @@ import { RequestController } from './controllers/request-ssto.controller';
 import { LogService } from './log/log.service';
 import { RequestService } from './request/request.service';
 import { SignalService } from './signal/signal.service';
-import { PdfService } from './services/pdf.service';
+import { PdfService } from './signal/pdf.service';
 
 // Models - только основные
 import Log from './models/log.model';


### PR DESCRIPTION
## Summary
- fix PdfService injection by importing it from signal module in AppModule

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c9bd5d60833099d389f092476acd