### PR TITLE
feat: add generic email sender

### DIFF
--- a/backend-nest/src/services/email.service.ts
+++ b/backend-nest/src/services/email.service.ts
@@ -184,6 +184,28 @@ export class EmailService {
   }
 
   /**
+   * Универсальная отправка email
+   */
+  async sendEmail(options: {
+    to: string;
+    subject: string;
+    text?: string;
+    html?: string;
+    attachments?: any[];
+  }): Promise<any> {
+    const mailOptions = {
+      from: this.configService.get('SMTP_USER'),
+      to: options.to,
+      subject: options.subject,
+      text: options.text,
+      html: options.html || options.text,
+      attachments: options.attachments || [],
+    };
+
+    return await this.transporter.sendMail(mailOptions);
+  }
+
+  /**
    * Отправка отчета по email
    */
   async sendTestReport(testData: any, pdfBuffer?: Buffer): Promise<void> {


### PR DESCRIPTION
## Summary
- add generic `sendEmail` helper to email service for wider usage

## Testing
- `npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps --no-audit --no-fund` *(fails: ENOTEMPTY directory not empty)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e94364fc833084519413740cf2d1