### PR TITLE
fix: import Op for request matching

### DIFF
--- a/backend-nest/src/services/request-processing.service.ts
+++ b/backend-nest/src/services/request-processing.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
+import { Op } from 'sequelize';
 import { EmailService } from './email.service';
 import SSASRequest from '../models/request.model';
 import SSASTerminal from '../models/ssas-terminal.model';


### PR DESCRIPTION
## Summary
- import Sequelize's Op in request-processing service to resolve undefined reference

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa447e648330b6394ea206fe4d54