### PR TITLE
fix: correct model imports in app and request services

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -15,15 +15,21 @@ import { AppService } from './app.service';
 import { PdfService } from './services/pdf.service';
 
 // Модули
-import { ApplicationsModule } from './applications/applications.module';
 import { EmailModule } from './email/email.module';
+import { RequestModule } from './request/request.module';
 
 // Sequelize модели
-import { SSASRequest } from './models/request.model';
-import { SSASTerminal } from './models/ssas-terminal.model';
-import { SSASSignal } from './models/ssas-signal.model';
-import { SystemSettings } from './models/system-settings.model';
-import { User } from './models/user.model';
+import SSASRequest from './models/request.model';
+import SSASTerminal from './models/ssas-terminal.model';
+import Signal from './models/signal.model';
+import SystemSettings from './models/system-settings.model';
+import User from './models/user.model';
+import Log from './models/log.model';
+import Vessel from './models/vessel.model';
+import TestRequest from './models/test-request.model';
+import TestReport from './models/test-report.model';
+import ConfirmationDocument from './models/confirmation-document.model';
+import TestingScenario from './models/testingScenario.model';
 
 @Module({
   imports: [
@@ -49,9 +55,15 @@ import { User } from './models/user.model';
         models: [
           SSASRequest,
           SSASTerminal,
-          SSASSignal,
+          Signal,
           SystemSettings,
-          User
+          User,
+          Log,
+          Vessel,
+          TestRequest,
+          TestReport,
+          ConfirmationDocument,
+          TestingScenario
         ],
         autoLoadModels: false, // Используем явную загрузку моделей
         synchronize: true, // В продакшене установить false
@@ -67,7 +79,7 @@ import { User } from './models/user.model';
     // Регистрация моделей для инъекций
     SequelizeModule.forFeature([
       SSASRequest,
-      SSASTerminal, 
+      SSASTerminal,
       Signal,
       SystemSettings,
       User,
@@ -76,13 +88,12 @@ import { User } from './models/user.model';
       TestRequest,
       TestReport,
       ConfirmationDocument,
-      TestingScenario
+      TestingScenario,
     ]),
 
     // Функциональные модули
-    ApplicationsModule,
-    EmailModule, // <-- EmailModule добавлен здесь
-    RequestModule, // <-- RequestModule добавлен здесь
+    EmailModule,
+    RequestModule,
 
   ],
   controllers: [

--- a/backend-nest/src/request/request.module.ts
+++ b/backend-nest/src/request/request.module.ts
@@ -10,11 +10,12 @@ import { EmailSenderService } from '../services/email-sender.service';
 import { ReportService } from '../services/report.service';
 import SSASRequest from '../models/request.model';
 import Signal from '../models/signal.model';
+import Vessel from '../models/vessel.model';
 
 @Module({
   imports: [
     ConfigModule,
-    SequelizeModule.forFeature([SSASRequest, Signal])
+    SequelizeModule.forFeature([SSASRequest, Signal, Vessel])
   ],
   controllers: [
     RequestController,

--- a/backend-nest/src/services/request-processing.service.ts
+++ b/backend-nest/src/services/request-processing.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/sequelize';
 import { Op } from 'sequelize';
 import { EmailService } from './email.service';
-import { SSASRequest } from '../models/request.model';
-import { SSASTerminal } from '../models/ssas-terminal.model';
+import SSASRequest from '../models/request.model';
+import SSASTerminal from '../models/ssas-terminal.model';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 @Injectable()

--- a/backend-nest/src/signal/signal.module.ts
+++ b/backend-nest/src/signal/signal.module.ts
@@ -9,12 +9,13 @@ import { EmailSenderService } from '../services/email-sender.service';
 import { ReportService } from '../services/report.service';
 import Signal from '../models/signal.model';
 import SSASRequest from '../models/request.model';
+import Vessel from '../models/vessel.model';
 import { SecurityModule } from '../security/security.module';
 
 @Module({
   imports: [
     ConfigModule,  // Для доступа к ConfigService
-    SequelizeModule.forFeature([Signal, SSASRequest]),
+    SequelizeModule.forFeature([Signal, SSASRequest, Vessel]),
     SecurityModule
   ],
   controllers: [SignalController],


### PR DESCRIPTION
## Summary
- fix broken module references in AppModule
- use default exports for request processing service models
- include Vessel model in RequestModule and SignalModule for SignalService

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npx tsc -p tsconfig.build.json` *(fails: Cannot find module 'jest' or its corresponding type declarations and many '@nestjs/*' type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b90c489fcc8330ab0a88f9ea0d06d9