### PR TITLE
Fix SSASRequest primary key mapping

### DIFF
--- a/backend-nest/src/models/request.model.ts
+++ b/backend-nest/src/models/request.model.ts
@@ -13,16 +13,7 @@ export default class SSASRequest extends Model {
     type: DataType.STRING,
     allowNull: false
   })
-  request_id: string;
-
-  // Virtual id alias for compatibility with existing code
-  get id(): string {
-    return this.request_id;
-  }
-
-  set id(value: string) {
-    this.request_id = value;
-  }
+  id: string;
 
   @Column({
     type: DataType.STRING(50),

--- a/backend-nest/src/services/email-parser.service.ts
+++ b/backend-nest/src/services/email-parser.service.ts
@@ -56,7 +56,7 @@ export class EmailParserService {
       vessel_name: vesselName,
       mmsi: mmsi,
       imo: imo,
-      request_id: `EMAIL${Date.now()}`,
+      id: `EMAIL${Date.now()}`,
       ssas_number: `SSAS${imo}`,
       owner_organization: this.extractOrganization(emailContent.from),
       contact_person: contactPerson,

--- a/backend-nest/src/services/report.service.ts
+++ b/backend-nest/src/services/report.service.ts
@@ -11,7 +11,7 @@ export class ReportService {
       margins: { top: 50, bottom: 50, left: 50, right: 50 }
     });
     
-    const fileName = `confirmation_${request.request_id}_${Date.now()}.pdf`;
+    const fileName = `confirmation_${request.id}_${Date.now()}.pdf`;
     const filePath = path.join(__dirname, '../../uploads/reports', fileName);
     
     if (!fs.existsSync(path.dirname(filePath))) {


### PR DESCRIPTION
## Summary
- use `request_id` column as the primary key and expose it as `id`
- adjust email parser and report service to work with new `id` field

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68b9228e819c83309824ebb2c28866d3