### PR TITLE
fix: remove manual id in email parser

### DIFF
--- a/backend-nest/src/services/email-parser.service.ts
+++ b/backend-nest/src/services/email-parser.service.ts
@@ -56,7 +56,6 @@ export class EmailParserService {
       vessel_name: vesselName,
       mmsi: mmsi,
       imo: imo,
-      id: `EMAIL${Date.now()}`,
       ssas_number: `SSAS${imo}`,
       owner_organization: this.extractOrganization(emailContent.from),
       contact_person: contactPerson,


### PR DESCRIPTION
## Summary
- remove string `id` assignment in email parser service and rely on DB-generated numeric ids

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0bfeff5c8330baba1d33096c3287