### PR TITLE
fix: replace TestRequest with SSASRequest

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -80,6 +80,8 @@ import { AuthGuard } from './security/auth.guard';
     
     // Регистрация моделей для инъекций в сервисы, которые не в модулях
     SequelizeModule.forFeature([
+      SSASRequest,
+      Signal,
       ConfirmationDocument,
       SSASTerminal,
       SystemSettings

--- a/backend-nest/src/services/enhanced-confirmation.service.ts
+++ b/backend-nest/src/services/enhanced-confirmation.service.ts
@@ -41,7 +41,7 @@ export class EnhancedConfirmationService {
       }
 
       // Ищем заявку по MMSI или позывному
-      const request = await this.testRequestModel.findOne({
+      const request = await this.requestModel.findOne({
         include: [Vessel],
         where: {
           status: 'approved',
@@ -99,7 +99,7 @@ export class EnhancedConfirmationService {
   // Подготовка подтверждения (создание документа без отправки)
   async prepareConfirmation(requestId: number): Promise<ConfirmationDocument> {
     try {
-      const request = await this.testRequestModel.findByPk(requestId, {
+      const request = await this.requestModel.findByPk(requestId, {
         include: [Vessel],
       });
 
@@ -143,7 +143,7 @@ export class EnhancedConfirmationService {
   async sendConfirmation(confirmationId: number, sentBy: string = 'MANUAL'): Promise<any> {
     try {
       const confirmation = await this.confirmationDocModel.findByPk(confirmationId, {
-        include: [{ model: TestRequest, include: [Vessel] }],
+        include: [{ model: SSASRequest, include: [Vessel] }],
       });
 
       if (!confirmation) {
@@ -225,7 +225,7 @@ export class EnhancedConfirmationService {
 
     return await this.confirmationDocModel.findAll({
       where,
-      include: [{ model: TestRequest, include: [Vessel] }],
+      include: [{ model: SSASRequest, include: [Vessel] }],
       order: [['created_at', 'DESC']],
     });
   }
@@ -249,7 +249,7 @@ export class EnhancedConfirmationService {
     };
   }
 
-  private generateConfirmationHtml(request: TestRequest, documentNumber: string): string {
+  private generateConfirmationHtml(request: SSASRequest, documentNumber: string): string {
     const vessel = null;
     const testDateTime = formatInTimeZone(
       request.test_date,


### PR DESCRIPTION
## Summary
- replace leftover TestRequest references with SSASRequest in EnhancedConfirmationService
- register SSASRequest and Signal models for injection in AppModule

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1577fdcc8330a353c7600e77bad3