### PR TITLE
Add test type to request model

### DIFF
--- a/backend-nest/src/models/request.model.ts
+++ b/backend-nest/src/models/request.model.ts
@@ -68,6 +68,13 @@ export default class SSASRequest extends Model {
   test_window_hours: number;
 
   @Column({
+    field: 'test_type',
+    type: DataType.STRING,
+    defaultValue: 'routine'
+  })
+  test_type: string;
+
+  @Column({
     field: 'inmarsat_number',
     type: DataType.STRING
   })


### PR DESCRIPTION
## Summary
- define `test_type` column in SSAS request model so services can access request test type

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1a42b4308330a186ab421d018a93