### PR TITLE
fix: remove duplicate root creation

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import React from 'react';
-import { createRoot } from 'react-dom/client';
 import { 
   AppBar, 
   Toolbar, 
@@ -113,23 +112,23 @@ function App() {
           <Routes>
             {/* Главная страница */}
             <Route path="/" element={<HomePage />} />
-            
+
             {/* Работа с заявками */}
             <Route path="/requests" element={<RequestList />} />
             <Route path="/request" element={<RequestForm />} />
-            
+
             {/* Мониторинг сигналов */}
             <Route path="/signals" element={<SignalMonitor />} />
-            
+
             {/* Тестирование */}
             <Route path="/testing" element={<TestingForm />} />
-            
+
             {/* Отчеты */}
             <Route path="/reports" element={<ReportsPage />} />
-            
+
             {/* Dashboard (legacy) */}
             <Route path="/dashboard" element={<Dashboard />} />
-            
+
             {/* Редирект для неизвестных маршрутов */}
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
@@ -137,12 +136,6 @@ function App() {
       </Box>
     </Router>
   );
-}
-
-// Точка входа приложения
-const container = document.getElementById('root');
-if (container) {
-  createRoot(container).render(<App />);
 }
 
 export default App;


### PR DESCRIPTION
## Summary
- remove extra `createRoot` call from the React app component to avoid double root initialization warnings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68bb228e543c8330853e3c95676fea21