### PR TITLE
feat: extend SSASRequest model

### DIFF
--- a/backend-nest/src/models/request.model.ts
+++ b/backend-nest/src/models/request.model.ts
@@ -46,6 +46,12 @@ export default class SSASRequest extends Model {
   mmsi: string;
 
   @Column({
+    field: 'imo_number',
+    type: DataType.STRING,
+  })
+  imo_number: string;
+
+  @Column({
     field: 'ssas_number',
     type: DataType.STRING,
   })
@@ -72,17 +78,23 @@ export default class SSASRequest extends Model {
   contact_phone: string;
 
   @Column({
-    field: 'email',
+    field: 'contact_email',
     type: DataType.STRING,
     allowNull: false,
   })
-  email: string;
+  contact_email: string;
 
   @Column({
     field: 'test_date',
     type: DataType.DATE,
   })
   test_date: Date;
+
+  @Column({
+    field: 'planned_test_date',
+    type: DataType.DATE,
+  })
+  planned_test_date: Date;
 
   @Column({
     field: 'start_time',
@@ -110,6 +122,13 @@ export default class SSASRequest extends Model {
   status: string;
 
   @Column({
+    field: 'test_type',
+    type: DataType.STRING,
+    defaultValue: 'routine',
+  })
+  test_type: string;
+
+  @Column({
     field: 'signal_received_time',
     type: DataType.STRING,
   })
@@ -126,6 +145,18 @@ export default class SSASRequest extends Model {
     type: DataType.STRING,
   })
   signal_strength: string;
+
+  @Column({
+    field: 'vessel_id',
+    type: DataType.INTEGER,
+  })
+  vessel_id: number;
+
+  @Column({
+    field: 'signal_id',
+    type: DataType.INTEGER,
+  })
+  signal_id: number;
 
   @Column({
     field: 'confirmation_sent_at',

--- a/backend-nest/src/services/report.service.ts
+++ b/backend-nest/src/services/report.service.ts
@@ -74,7 +74,7 @@ export class ReportService {
     // Email адреса
     doc.text('Covert message setup:', 50, 415);
     doc.text(`E-mail:od_smrcc@morflot.ru`, 50, 430);
-    doc.text(`E-mail:${request.email}`, 50, 445);
+    doc.text(`E-mail:${request.contact_email}`, 50, 445);
     if (request.contact_phone) {
       doc.text(`E-mail:${request.contact_person.toLowerCase().replace(' ', '_')}@volgaflot.com`, 50, 460);
     }


### PR DESCRIPTION
## Summary
- add missing fields to SSASRequest model used by backend services
- update report generation to use new contact email field

## Testing
- `node_modules/typescript/bin/tsc -p tsconfig.build.json` (fails: Cannot find type definition file for 'bcrypt')
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bb2dbd2c5c8330949351591e2c8236