### PR TITLE
Avoid 500 errors when fetching requests

### DIFF
--- a/backend-nest/src/controllers/request-ssto.controller.ts
+++ b/backend-nest/src/controllers/request-ssto.controller.ts
@@ -56,10 +56,14 @@ export class RequestController {
         data: requests,
       });
     } catch (error) {
-      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      // If the database is unavailable or another error occurs we do not want
+      // to surface a 500 error to the frontend.  Returning an empty list keeps
+      // the UI functional even when the backend cannot reach the database.
+      console.error('Error fetching requests:', error);
+      return res.status(HttpStatus.OK).json({
         success: false,
-        message: 'Ошибка получения заявок',
-        error: error.message,
+        count: 0,
+        data: [],
       });
     }
   }

--- a/backend-nest/src/request/request.service.ts
+++ b/backend-nest/src/request/request.service.ts
@@ -34,7 +34,16 @@ export class RequestService {
   ) {}
 
   async findAll() {
-    return this.reqModel.findAll();
+    try {
+      // If the database is unreachable or the query fails we don't want the
+      // whole `/requests` endpoint to crash with a 500 error.  Instead we log
+      // the problem and return an empty list so that the frontend can handle
+      // the situation gracefully.
+      return await this.reqModel.findAll();
+    } catch (error) {
+      console.error('Failed to fetch requests:', error);
+      return [];
+    }
   }
 
   async findOne(id: string) {


### PR DESCRIPTION
## Summary
- Prevent database errors from crashing `/requests` API by returning an empty list when the query fails
- Respond with HTTP 200 and an empty dataset instead of 500 so the frontend can continue working

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb4e10c524833087e777a360f2dcb2