### PR TITLE
Fix TypeScript build issues for signal reports

### DIFF
--- a/backend-nest/src/models/signal.model.ts
+++ b/backend-nest/src/models/signal.model.ts
@@ -33,6 +33,12 @@ export default class Signal extends Model {
 
   @Column({
     type: DataType.STRING,
+    allowNull: true
+  })
+  vessel_name: string;
+
+  @Column({
+    type: DataType.STRING,
     defaultValue: 'TEST'
   })
   signal_type: string;

--- a/backend-nest/src/services/report.service.ts
+++ b/backend-nest/src/services/report.service.ts
@@ -104,4 +104,19 @@ export class ReportService {
     doc.end();
     return filePath;
   }
+
+  async generateForSignal(signal: any): Promise<string> {
+    const request =
+      signal?.request ??
+      signal?.ssas_request ??
+      signal?.SSASRequest ??
+      signal?.['Request'] ??
+      null;
+
+    if (!request) {
+      throw new Error('Cannot generate report without linked request');
+    }
+
+    return this.generateTestConfirmation(request, signal);
+  }
 }


### PR DESCRIPTION
## Summary
- add the missing `vessel_name` column to the Signal Sequelize model so the TypeScript definitions match the service usage
- provide a `generateForSignal` helper in the report service that reuses the confirmation generator when a linked request is present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55c99a2108330a800178afec8db87