### PR TITLE
Fix signal report generation build errors

### DIFF
--- a/backend-nest/src/models/signal.model.ts
+++ b/backend-nest/src/models/signal.model.ts
@@ -33,6 +33,12 @@ export default class Signal extends Model {
 
   @Column({
     type: DataType.STRING,
+    allowNull: true,
+  })
+  vessel_name: string;
+
+  @Column({
+    type: DataType.STRING,
     defaultValue: 'TEST'
   })
   signal_type: string;


### PR DESCRIPTION
## Summary
- add the missing vessel_name column to the Signal Sequelize model so recent signal listings compile
- extend the report service with a general generateForSignal helper and shared report directory handling
- create a fallback PDF report for signals without linked requests while reusing the confirmation template when a request exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55c99a2108330a800178afec8db87