### PR TITLE
Fix SignalModule provider dependencies

### DIFF
--- a/backend-nest/src/signal/signal.module.ts
+++ b/backend-nest/src/signal/signal.module.ts
@@ -4,8 +4,9 @@
 import { Module } from '@nestjs/common';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { SignalController } from '../controllers/signal.controller';
-import { SignalService } from './signal.service';
+import { SignalService } from '../services/signal.service';
 import { PdfService } from './pdf.service';
+import { ReportService } from '../services/report.service';
 import Signal from '../models/signal.model';
 import SSASRequest from '../models/request.model';
 import Vessel from '../models/vessel.model';
@@ -15,7 +16,7 @@ import Vessel from '../models/vessel.model';
     SequelizeModule.forFeature([Signal, SSASRequest, Vessel])
   ],
   controllers: [SignalController],
-  providers: [SignalService, PdfService],
+  providers: [SignalService, PdfService, ReportService],
   exports: [SignalService, PdfService]
 })
 export class SignalModule {}


### PR DESCRIPTION
## Summary
- align `SignalModule` with the controller by wiring it to the shared `SignalService` and its dependencies
- register `ReportService` so report generation features used by the signal service resolve correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d58e4c2d548330936dc836a29688a1