### PR TITLE
Fix incorrect backend import paths for email and auth services

### DIFF
--- a/backend-nest/src/app.module.ts
+++ b/backend-nest/src/app.module.ts
@@ -7,19 +7,19 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { EmailController } from './email/email.controller';
 import { HealthController } from './controllers/health.controller';
-import { DevAuthController } from './auth/dev-auth.controller';
+import { DevAuthController } from './dev-auth/dev-auth.controller';
 
 // Services  
 import { AppService } from './app.service';
-import { EmailSenderService } from './email/email-sender.service';
-import { EmailParserService } from './email/email-parser.service';
-import { EmailTaskService } from './email/email-task.service';
-import { EmailService } from './email/email.service';
+import { EmailSenderService } from './services/email-sender.service';
+import { EmailParserService } from './services/email-parser.service';
+import { EmailTaskService } from './services/email-task.service';
+import { EmailService } from './services/email.service';
 import { EnhancedConfirmationService } from './services/enhanced-confirmation.service';
 import { ReportService } from './services/report.service';
 import { RequestProcessingService } from './services/request-processing.service';
-import { AuthService } from './auth/auth.service';
-import { AuthGuard } from './auth/auth.guard';
+import { AuthService } from './security/auth.service';
+import { AuthGuard } from './security/auth.guard';
 
 // Modules
 import { RequestModule } from './request/request.module';


### PR DESCRIPTION
## Summary
- update the backend NestJS module to point email-related services to their actual location under src/services
- import the dev auth controller and auth service/guard from their correct folders so TypeScript can resolve them during Docker builds

## Testing
- npm run build --prefix backend-nest

------
https://chatgpt.com/codex/tasks/task_e_68dbd9ad4c088330a9466d6c21c384cd