### PR TITLE
Restore Nest scripts, guard production start, and fix Docker tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,7 +46,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha
             
       - name: Build and push Backend Docker image
         uses: docker/build-push-action@v5
@@ -70,7 +70,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix={{branch}}-
+            type=sha
             
       - name: Build and push Frontend Docker image
         uses: docker/build-push-action@v5

--- a/backend-nest/README.md
+++ b/backend-nest/README.md
@@ -2,6 +2,7 @@
 ## Быстрый старт
 - Установить зависимости: `npm install`
 - Запустить dev: `npm run start:dev`
+- Собрать и запустить prod: `npm run start:prod` (скрипт автоматически выполнит `npm run build`, если отсутствует `dist/main.js`)
 ## Структура
 - src/models — Sequelize модели (PostgreSQL)
 - src/controllers — REST API-контроллеры

--- a/backend-nest/package.json
+++ b/backend-nest/package.json
@@ -10,7 +10,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main.js",
+    "start:prod": "node ./scripts/start-prod.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/backend-nest/scripts/start-prod.js
+++ b/backend-nest/scripts/start-prod.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+
+const projectRoot = resolve(__dirname, '..');
+const distMain = join(projectRoot, 'dist', 'main.js');
+
+function buildIfNeeded() {
+  if (existsSync(distMain)) {
+    return true;
+  }
+
+  console.log('dist/main.js not found. Running "npm run build" to compile the project...');
+  const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSync(npmCmd, ['run', 'build'], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+    env: process.env,
+  });
+
+  if (result.status !== 0) {
+    console.error('\nFailed to compile the backend. See the build output above for details.');
+    return false;
+  }
+
+  if (!existsSync(distMain)) {
+    console.error('\nThe build completed but dist/main.js is still missing. Confirm that tsconfig.build.json outputs to ./dist.');
+    return false;
+  }
+
+  return true;
+}
+
+if (!buildIfNeeded()) {
+  process.exit(1);
+}
+
+const nodeArgs = [distMain, ...process.argv.slice(2)];
+const runResult = spawnSync(process.execPath, nodeArgs, {
+  cwd: projectRoot,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (runResult.error) {
+  throw runResult.error;
+}
+
+process.exit(runResult.status ?? 0);


### PR DESCRIPTION
## Summary
- revert backend scripts to call the standard Nest CLI commands so local workflows stay unchanged
- add a production start helper that auto-runs the build when dist/main.js is missing and surfaces actionable errors
- document the start:prod helper in the backend README and restore the original TypeScript compiler settings
- fix the Docker build workflow so SHA tags no longer generate invalid image references when the branch name is unavailable

## Testing
- npm --prefix backend-nest run start:prod *(fails because @nestjs/cli is not available in this execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e631a9feb883308b5f0ddbea0a1868